### PR TITLE
Fix badge urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ Contribution to Ascend is deeply appreciated. When submitting pull requests, abi
 ###### We build & use Ascend on Java 17 - [Eclipse Temurin](https://adoptium.net/).
 ###### Also build & run Ascend with [Eclipse Temurin](https://adoptium.net/) to get the best possible experience!
 
-[![Open Source](https://forthebadge.com/images/badges/open-source.svg)](https://github.com/TheFruxz/Ascend/blob/main/LICENSE)
-[![Built by developers](https://forthebadge.com/images/badges/built-by-developers.svg)](https://github.com/TheFruxz/Ascend/graphs/contributors)
-[![Written in Kotlin](https://forthebadge.com/images/badges/makes-people-smile.svg)](https://github.com/JetBrains/kotlin)
+[![Open Source](https://raw.githubusercontent.com/BraveUX/for-the-badge/master/src/images/badges/open-source.svg)](https://github.com/TheFruxz/Sparkle/blob/main/LICENSE)
+[![Built by developers](https://raw.githubusercontent.com/BraveUX/for-the-badge/master/src/images/badges/built-by-developers.svg)](https://github.com/TheFruxz/Sparkle/graphs/contributors)
+[![Written in Kotlin](https://raw.githubusercontent.com/BraveUX/for-the-badge/master/src/images/badges/makes-people-smile.svg)](https://github.com/JetBrains/kotlin)


### PR DESCRIPTION
Due to a down webserver, we should use the direct github links to the badges of forthebadge